### PR TITLE
feat: make footer non-sticky

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -29,7 +29,7 @@ const entries = [
 
 export function Footer() {
   return (
-    <footer className="w-full mt-auto border-t border-border bg-background/80 backdrop-blur-sm sticky bottom-0 z-10">
+    <footer className="w-full mt-auto border-t border-border bg-background/80">
       <div className="max-w-7xl mx-auto px-4 py-6">
         <div className="flex justify-center items-center gap-1">
           {entries.map((entry, index) => (


### PR DESCRIPTION
especially on small screens the footer takes up quite a lot of space on the settings page:

<img width="585" height="1266" alt="IMG_2556" src="https://github.com/user-attachments/assets/6addd30b-c96c-403c-9f7b-add63c96634c" />

